### PR TITLE
Present auth error to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Unhandled authentication/authorization error was not reported to user
+
 ## 2.2.0 - 2020-10-29
 
 ### Changed


### PR DESCRIPTION
The integration currently fails in a way that hides the cause of the error from the user. This will inform them that they have not the permissions required to read an endpoint and help them along in the right direction.