### PR TITLE
INT-2367 - Add Commit Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+- Commits for MRs are now added. They are only related to MRs at this time, as
+the required data doesn't exist to have a durable relationship creation process
+between users and commits.
 ## 4.2.0 - 2022-01-21
 
 ### Fixed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -82,6 +82,7 @@ The following entities are created:
 | Resources     | Entity `_type`         | Entity `_class`       |
 | ------------- | ---------------------- | --------------------- |
 | Account       | `gitlab_account`       | `Account`             |
+| Commit        | `gitlab_commit`        | `CodeCommit`          |
 | Group         | `gitlab_group`         | `Group`               |
 | Merge Request | `gitlab_merge_request` | `CodeReview`, `PR`    |
 | Project       | `gitlab_project`       | `CodeRepo`, `Project` |
@@ -91,17 +92,18 @@ The following entities are created:
 
 The following relationships are created:
 
-| Source Entity `_type` | Relationship `_class` | Target Entity `_type`  |
-| --------------------- | --------------------- | ---------------------- |
-| `gitlab_account`      | **HAS**               | `gitlab_group`         |
-| `gitlab_account`      | **HAS**               | `gitlab_project`       |
-| `gitlab_group`        | **HAS**               | `gitlab_group`         |
-| `gitlab_group`        | **HAS**               | `gitlab_project`       |
-| `gitlab_group`        | **HAS**               | `gitlab_user`          |
-| `gitlab_project`      | **HAS**               | `gitlab_merge_request` |
-| `gitlab_project`      | **HAS**               | `gitlab_user`          |
-| `gitlab_user`         | **APPROVED**          | `gitlab_merge_request` |
-| `gitlab_user`         | **OPENED**            | `gitlab_merge_request` |
+| Source Entity `_type`  | Relationship `_class` | Target Entity `_type`  |
+| ---------------------- | --------------------- | ---------------------- |
+| `gitlab_account`       | **HAS**               | `gitlab_group`         |
+| `gitlab_account`       | **HAS**               | `gitlab_project`       |
+| `gitlab_group`         | **HAS**               | `gitlab_group`         |
+| `gitlab_group`         | **HAS**               | `gitlab_project`       |
+| `gitlab_group`         | **HAS**               | `gitlab_user`          |
+| `gitlab_merge_request` | **HAS**               | `gitlab_commit`        |
+| `gitlab_project`       | **HAS**               | `gitlab_merge_request` |
+| `gitlab_project`       | **HAS**               | `gitlab_user`          |
+| `gitlab_user`          | **APPROVED**          | `gitlab_merge_request` |
+| `gitlab_user`          | **OPENED**            | `gitlab_merge_request` |
 
 <!--
 ********************************************************************************

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const Steps = {
   GROUPS: 'fetch-groups',
   PROJECTS: 'fetch-projects',
   MERGE_REQUESTS: 'fetch-merge-requests',
+  COMMITS: 'fetch-mr-commits',
   BUILD_ACCOUNT_HAS_PROJECT: 'build-account-project-relationships',
   BUILD_ACCOUNT_HAS_GROUP: 'build-account-group-relationships',
   BUILD_PROJECT_HAS_USER: 'build-project-user-relationships',
@@ -37,6 +38,11 @@ export const Entities = {
     resourceName: 'Merge Request',
     _type: 'gitlab_merge_request',
     _class: ['CodeReview', 'PR'],
+  },
+  COMMIT: {
+    resourceName: 'Commit',
+    _type: 'gitlab_commit',
+    _class: ['CodeCommit'],
   },
   PROJECT: {
     resourceName: 'Project',
@@ -99,5 +105,11 @@ export const Relationships = {
     sourceType: Entities.USER._type,
     _class: RelationshipClass.APPROVED,
     targetType: Entities.MERGE_REQUEST._type,
+  },
+  MR_HAS_COMMIT: {
+    _type: 'gitlab_merge_request_has_commit',
+    sourceType: Entities.MERGE_REQUEST._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.COMMIT._type,
   },
 };

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -7,6 +7,7 @@ import {
 import { Entities } from '../constants';
 import {
   GitLabMergeRequest,
+  GitLabMergeCommitRequest,
   GitLabMergeRequestApproval,
   GitLabProject,
   GitLabUser,
@@ -160,7 +161,47 @@ export function createMergeRequestEntity(
   });
 }
 
+export function createMergeRequestCommitEntity(
+  mergeRequest: GitLabMergeRequest,
+  mergeRequestCommit: GitLabMergeCommitRequest,
+): Entity {
+  const key = createCommitIdentifier(mergeRequestCommit.id);
+
+  return createIntegrationEntity({
+    entityData: {
+      source: mergeRequestCommit,
+      assign: {
+        _key: key,
+        _type: Entities.COMMIT._type,
+        _class: Entities.COMMIT._class,
+        id: String(mergeRequestCommit.id),
+        shortId: String(mergeRequestCommit.short_id),
+        title: mergeRequestCommit.title,
+        name: mergeRequestCommit.title,
+        branch: mergeRequest.source_branch,
+        merge: false,
+        versionBump: false,
+        createdOn: parseTimePropertyValue(mergeRequestCommit.created_at),
+        webLink: mergeRequestCommit.web_url,
+        message: mergeRequestCommit.message,
+        authoredOn: parseTimePropertyValue(mergeRequestCommit.authored_date),
+        committedOn: parseTimePropertyValue(mergeRequestCommit.committed_date),
+        commitWebLink: mergeRequestCommit.web_url,
+        committerName: mergeRequestCommit.committer_name,
+        committerEmail: mergeRequestCommit.committer_email,
+        authorName: mergeRequestCommit.author_name,
+        authorEmail: mergeRequestCommit.author_email,
+      },
+    },
+  });
+}
+
 const MERGE_REQUEST_ID_PREFIX = 'gitlab-merge-request';
 export function createMergeRequestEntityIdentifier(id: number): string {
   return `${MERGE_REQUEST_ID_PREFIX}:${id}`;
+}
+
+const COMMIT_ID_PREFIX = 'gitlab-commit';
+export function createCommitIdentifier(id: number): string {
+  return `${COMMIT_ID_PREFIX}:${id}`;
 }

--- a/src/provider/GitlabClient.ts
+++ b/src/provider/GitlabClient.ts
@@ -43,15 +43,17 @@ export class GitlabClient {
   }
 
   async fetchAccount(): Promise<GitLabUser> {
-    return this.makeSingularRequest(HttpMethod.GET, '/user') as Promise<
-      GitLabUser
-    >;
+    return this.makeSingularRequest(
+      HttpMethod.GET,
+      '/user',
+    ) as Promise<GitLabUser>;
   }
 
   async fetchUser(id: number): Promise<GitLabUser> {
-    return this.makeSingularRequest(HttpMethod.GET, `/users/${id}`) as Promise<
-      GitLabUser
-    >;
+    return this.makeSingularRequest(
+      HttpMethod.GET,
+      `/users/${id}`,
+    ) as Promise<GitLabUser>;
   }
 
   async fetchGroups(): Promise<GitLabGroup[]> {
@@ -87,6 +89,23 @@ export class GitlabClient {
       {
         onPageError: options.onPageError,
         params: { updated_after: options.updatedAfter.toISOString() },
+      },
+    );
+  }
+
+  async iterateMergeRequestCommits(
+    projectId: number,
+    mergeRequestNumber: number,
+    iteratee: ResourceIteratee<GitLabMergeRequest>,
+    options: {
+      onPageError: PageErrorHandler;
+    },
+  ): Promise<void> {
+    return this.iterateResources(
+      `/projects/${projectId}/merge_requests/${mergeRequestNumber}/commits`,
+      iteratee,
+      {
+        onPageError: options.onPageError,
       },
     );
   }

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -55,6 +55,8 @@ export type GitLabProject = Opaque<any, 'GitLabProject'>;
 
 export type GitLabMergeRequest = Opaque<any, 'GitLabMergeRequest'>;
 
+export type GitLabMergeCommitRequest = Opaque<any, 'GitLabMergeCommitRequest'>;
+
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-configuration-1
 export type GitLabMergeRequestApproval = Opaque<
   any,

--- a/src/steps/commits.ts
+++ b/src/steps/commits.ts
@@ -74,7 +74,7 @@ export const commitSteps: IntegrationStep<GitlabIntegrationConfig>[] = [
     name: 'Fetch MR commits',
     entities: [Entities.COMMIT],
     relationships: [Relationships.MR_HAS_COMMIT],
-    dependsOn: [Steps.MERGE_REQUESTS, Steps.USERS],
+    dependsOn: [Steps.MERGE_REQUESTS],
     executionHandler: fetchCommits,
   },
 ];

--- a/src/steps/commits.ts
+++ b/src/steps/commits.ts
@@ -1,0 +1,80 @@
+import { v4 as uuid } from 'uuid';
+
+import {
+  createDirectRelationship,
+  getRawData,
+  IntegrationProviderAuthorizationError,
+  IntegrationStep,
+  IntegrationStepExecutionContext,
+} from '@jupiterone/integration-sdk-core';
+
+import { Entities, Relationships, Steps } from '../constants';
+import { createMergeRequestCommitEntity } from '../converters';
+import { createGitlabClient } from '../provider';
+import { GitLabMergeRequest } from '../provider/types';
+import { GitlabIntegrationConfig } from '../types';
+
+export async function fetchCommits({
+  logger,
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext<GitlabIntegrationConfig>) {
+  const client = createGitlabClient(instance.config);
+
+  const errorCorrelationId = uuid();
+
+  await jobState.iterateEntities(
+    { _type: Entities.MERGE_REQUEST._type },
+    async (mergeRequestEntity) => {
+      const mergeRequest = getRawData(mergeRequestEntity) as GitLabMergeRequest;
+      await client.iterateMergeRequestCommits(
+        mergeRequest.project_id,
+        mergeRequest.iid,
+        async (mergeRequestCommit) => {
+          const commitEntity = await jobState.addEntity(
+            createMergeRequestCommitEntity(mergeRequest, mergeRequestCommit),
+          );
+          await jobState.addRelationship(
+            createDirectRelationship({
+              _class: Relationships.MR_HAS_COMMIT._class,
+              from: mergeRequestEntity,
+              to: commitEntity,
+            }),
+          );
+        },
+        {
+          onPageError: ({ err, endpoint }) => {
+            const logDetail = {
+              err,
+              endpoint,
+              projectId: mergeRequest.projectId,
+              errorCorrelationId,
+            };
+            if (err instanceof IntegrationProviderAuthorizationError) {
+              logger.warn(
+                logDetail,
+                'Unauthorized to fetch merge request commits for project',
+              );
+            } else {
+              logger.error(
+                logDetail,
+                'Failed to fetch merge request commits for project',
+              );
+            }
+          },
+        },
+      );
+    },
+  );
+}
+
+export const commitSteps: IntegrationStep<GitlabIntegrationConfig>[] = [
+  {
+    id: Steps.COMMITS,
+    name: 'Fetch MR commits',
+    entities: [Entities.COMMIT],
+    relationships: [Relationships.MR_HAS_COMMIT],
+    dependsOn: [Steps.MERGE_REQUESTS, Steps.USERS],
+    executionHandler: fetchCommits,
+  },
+];

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -16,6 +16,7 @@ import groupStep from './fetch-groups';
 import { mergeRequestSteps } from './merge-requests';
 import { projectSteps } from './projects';
 import { userSteps } from './users';
+import { commitSteps } from './commits';
 
 const integrationSteps: Step<
   IntegrationStepExecutionContext<GitlabIntegrationConfig>
@@ -32,6 +33,7 @@ const integrationSteps: Step<
   ...mergeRequestSteps,
   projectMergeRequestStep,
   userOpenedMergeRequestStep,
+  ...commitSteps,
 ];
 
 export { integrationSteps };


### PR DESCRIPTION
Adding MR commit info.  

At this time, there is no durable way to create and maintain relationships between commits and users, so the author and committer data currently resides only on the commit entity itself.  In the future if the Gitlab API changes to provide a user ID for commit data, we can modify this to create the correct relationships between commits and users.