### PR TITLE
Checking for instance where the same commit can exist across multiple MRs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,7 @@ export const Entities = {
   COMMIT: {
     resourceName: 'Commit',
     _type: 'gitlab_commit',
-    _class: ['CodeCommit'],
+    _class: ['Entity'],
   },
   PROJECT: {
     resourceName: 'Project',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,7 @@ export const Entities = {
   COMMIT: {
     resourceName: 'Commit',
     _type: 'gitlab_commit',
-    _class: ['Entity'],
+    _class: ['CodeCommit'],
   },
   PROJECT: {
     resourceName: 'Project',

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -162,7 +162,6 @@ export function createMergeRequestEntity(
 }
 
 export function createMergeRequestCommitEntity(
-  mergeRequest: GitLabMergeRequest,
   mergeRequestCommit: GitLabMergeCommitRequest,
 ): Entity {
   const key = createCommitIdentifier(mergeRequestCommit.id);
@@ -178,7 +177,7 @@ export function createMergeRequestCommitEntity(
         shortId: String(mergeRequestCommit.short_id),
         title: mergeRequestCommit.title,
         name: mergeRequestCommit.title,
-        branch: mergeRequest.source_branch,
+        displayName: mergeRequestCommit.title,
         merge: false,
         versionBump: false,
         createdOn: parseTimePropertyValue(mergeRequestCommit.created_at),

--- a/src/steps/commits.ts
+++ b/src/steps/commits.ts
@@ -9,7 +9,7 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { Entities, Relationships, Steps } from '../constants';
-import { createMergeRequestCommitEntity } from '../converters';
+import { createMergeRequestCommitEntity, createCommitIdentifier } from '../converters';
 import { createGitlabClient } from '../provider';
 import { GitLabMergeRequest } from '../provider/types';
 import { GitlabIntegrationConfig } from '../types';
@@ -31,9 +31,12 @@ export async function fetchCommits({
         mergeRequest.project_id,
         mergeRequest.iid,
         async (mergeRequestCommit) => {
-          const commitEntity = await jobState.addEntity(
-            createMergeRequestCommitEntity(mergeRequest, mergeRequestCommit),
-          );
+          let commitEntity = await jobState.findEntity(createCommitIdentifier(mergeRequestCommit.id))
+          if(!commitEntity) {
+            commitEntity = await jobState.addEntity(
+              createMergeRequestCommitEntity(mergeRequest, mergeRequestCommit),
+            );
+          }
           await jobState.addRelationship(
             createDirectRelationship({
               _class: Relationships.MR_HAS_COMMIT._class,

--- a/src/steps/commits.ts
+++ b/src/steps/commits.ts
@@ -34,7 +34,7 @@ export async function fetchCommits({
           let commitEntity = await jobState.findEntity(createCommitIdentifier(mergeRequestCommit.id))
           if(!commitEntity) {
             commitEntity = await jobState.addEntity(
-              createMergeRequestCommitEntity(mergeRequest, mergeRequestCommit),
+              createMergeRequestCommitEntity(mergeRequestCommit),
             );
           }
           await jobState.addRelationship(


### PR DESCRIPTION
Adding in a check for one commit included in multiple MRs to fix a Sentry issue that came in over the weekend on the new commit data we recently added to this integration.  See below example data showing one commit related to two MRs.  For this example, I created a branch, added a commit, created a branch off of it, and then did MRs from both branches into main.

![image](https://user-images.githubusercontent.com/55771823/154973852-423a0864-1c82-46a7-9392-8473110ff5f5.png)
