### PR TITLE
Release 4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 4.4.2 - 2023-03-14
+
 ## Changed
 
 - Due to how the `/users/*` API handles rate limiting, add logic to wait 10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-gitlab",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "A JupiterOne Integration",
   "license": "MPL-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
## 4.4.2 - 2023-03-14

## Changed

- Due to how the `/users/*` API handles rate limiting, add logic to wait 10
  minutes if we encounter a 429 in the `fetch-users` step
- Updated `@jupiterone/integration-sdk-*` packages to `v8.30.5`
- Introduced new SDK testing patterns for `fetch-users` step