### PR TITLE
INT-7811: the auto process on changelog.md is failing prettier - disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-## 4.4.4 - 2023-05-03
+## 4.4.4 - 2023-05-15
 
 ## Added
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     ],
     "onlyPublishWithReleaseLabel": true,
     "shipit": {
+      "noChangelog": true,
       "prerelease": false
     }
   }


### PR DESCRIPTION
During the build automation, the `auto` package was generating a new CHNAGELOG.md, but it was failing the prettier check and the build would stop as a result. This update is to disable auto changelog generation.