### PR TITLE
Create Packages from Integration

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
+      - name: Lowercase the repo name
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -56,6 +59,5 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Sign the images with GH OIDC Token
         run:
-          COSIGN_REPOSITORY=ghcr.io/${{ github.repository }}-signatures cosign
-          sign -y ghcr.io/${{ github.repository }}@${{
-          steps.build-and-push.outputs.DIGEST }}
+          COSIGN_REPOSITORY=ghcr.io/${{ env.REPO }}-signatures cosign sign -y
+          ghcr.io/${{ env.REPO }}@${{ steps.build-and-push.outputs.DIGEST }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,0 +1,61 @@
+name: Build and Package
+
+on:
+  push:
+    tags: '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      #    tags: type=sha,format=long
+
+      # Build and push Docker image
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the Docker image (Using OIDC Token for "keyless signing")
+      # https://github.com/sigstore/cosign-installer
+      - name: Sign the images with GH OIDC Token
+        run:
+          COSIGN_REPOSITORY=ghcr.io/${{ github.repository }}-signatures cosign
+          sign -y ghcr.io/${{ github.repository }}@${{
+          steps.build-and-push.outputs.DIGEST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14-alpine
+
+ENV JUPITERONE_INTEGRATION_DIR=/opt/jupiterone/integration
+
+COPY package.json yarn.lock tsconfig.json LICENSE ${JUPITERONE_INTEGRATION_DIR}/
+COPY src/ ${JUPITERONE_INTEGRATION_DIR}/src
+
+WORKDIR ${JUPITERONE_INTEGRATION_DIR}
+RUN yarn install
+
+ENTRYPOINT /usr/local/bin/yarn j1-integration run -i ${INTEGRATION_INSTANCE_ID} --disable-schema-validation --api-base-url ${JUPITERONE_API_BASE_URL:-https://api.us.jupiterone.io} --account ${JUPITERONE_ACCOUNT} --api-key ${JUPITERONE_API_KEY}


### PR DESCRIPTION
# Description

This introduces a GitHub workflow to create a signed GitHub package from the integration upon tag push. This is achieved though a Dockerfile and a package-publish action. The signing is keyless signing using cosign.

The integration code itself is unchanged. The package was tested (successfully) using an AWS Managed Microsoft AD lab environment, pushing data into a JupiterOne EU account.