### PR TITLE
INT-6664: update errors

### DIFF
--- a/src/steps/findings.ts
+++ b/src/steps/findings.ts
@@ -24,23 +24,33 @@ export async function fetchVulnerabilityFindings({
     async (projectEntity) => {
       const project = getRawData(projectEntity) as GitLabProject;
 
-      await client.iterateProjectVulnerabilities(
-        project.id,
-        async (finding) => {
-          const findingEntity = createVulnerabilityFindingEntity(finding);
+      try {
+        await client.iterateProjectVulnerabilities(
+          project.id,
+          async (finding) => {
+            const findingEntity = createVulnerabilityFindingEntity(finding);
 
-          await Promise.all([
-            jobState.addEntity(findingEntity),
-            jobState.addRelationship(
-              createDirectRelationship({
-                _class: RelationshipClass.HAS,
-                from: projectEntity,
-                to: findingEntity,
-              }),
-            ),
-          ]);
-        },
-      );
+            await Promise.all([
+              jobState.addEntity(findingEntity),
+              jobState.addRelationship(
+                createDirectRelationship({
+                  _class: RelationshipClass.HAS,
+                  from: projectEntity,
+                  to: findingEntity,
+                }),
+              ),
+            ]);
+          },
+        );
+      } catch (e) {
+        if (e.status === 403) {
+          logger.warn(
+            `User does not have permission to fetch findings for project ${project.id}. Please ensure access type is either Developer, 	Maintainer or Owner for this project.`,
+          );
+        } else {
+          throw e;
+        }
+      }
     },
   );
 }

--- a/src/steps/users.ts
+++ b/src/steps/users.ts
@@ -26,12 +26,22 @@ export async function fetchUsers({
   await jobState.iterateEntities(
     { _type: Entities.GROUP._type },
     async (group) => {
-      const members = await client.fetchGroupMembers(
-        parseInt(group.id as string, 10),
-      );
+      try {
+        const members = await client.fetchGroupMembers(
+          parseInt(group.id as string, 10),
+        );
 
-      for (const member of members) {
-        userIds.add(member.id);
+        for (const member of members) {
+          userIds.add(member.id);
+        }
+      } catch (e) {
+        if (e.status === 403) {
+          logger.warn(
+            `User does not have permission to fetch members of group ${group.id}. Please ensure this user has the right access type.`,
+          );
+        } else {
+          throw e;
+        }
       }
     },
   );
@@ -39,12 +49,22 @@ export async function fetchUsers({
   await jobState.iterateEntities(
     { _type: Entities.PROJECT._type },
     async (project) => {
-      const members = await client.fetchProjectMembers(
-        parseInt(project.id as string, 10),
-      );
+      try {
+        const members = await client.fetchProjectMembers(
+          parseInt(project.id as string, 10),
+        );
 
-      for (const member of members) {
-        userIds.add(member.id);
+        for (const member of members) {
+          userIds.add(member.id);
+        }
+      } catch (e) {
+        if (e.status === 403) {
+          logger.warn(
+            `User does not have permission to fetch members of project ${project.id}. Please ensure this user has the right access type.`,
+          );
+        } else {
+          throw e;
+        }
       }
     },
   );


### PR DESCRIPTION
Bonus change:

`Many` times a user can be just invited to an organization project but not to a complete group. For each action, if the error code is a 403, means the user does not have the right access types to perform that action (although it might have a full permissions personal token). In my opinion, this must `not` be treated as an error, because its very likely a user will be invited to external repos, but not be able to fetch vulnerabilities or be part of the complete group.